### PR TITLE
Add gitattributes for vunk highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.vunk linguist-language=scala


### PR DESCRIPTION
In vim, highlighting vunk as Scala looks okayish... so lets have that in github for now.
