### PR TITLE
Alter generic-function syntax

### DIFF
--- a/vunk-examples/0039.vunk
+++ b/vunk-examples/0039.vunk
@@ -26,7 +26,7 @@ impl Ageing on Aninmal =
       ageing = (Animal { name, age }) -> Animal { name, age: age + 1 }
     }
 
-grow_old: (A) -> A
+grow_old A: (A) -> A
     where A: Ageing;
 grow_old = (a: A) -> Ageing.ageing (Ageing.ageing a);
 

--- a/vunk-examples/0040.vunk
+++ b/vunk-examples/0040.vunk
@@ -69,7 +69,7 @@ impl Printable on Animal =
         in String.fmt "{} is {} old" [name age];
     }
 
-grow_old: (A) -> A
+grow_old A: (A) -> A
     where A: Ageing;
 grow_old = (a: A) -> Ageing.ageing (Ageing.ageing a);
 

--- a/vunk-examples/0041.vunk
+++ b/vunk-examples/0041.vunk
@@ -111,7 +111,7 @@ impl Printable on Animal =
 #
 # When implementing generic functions, the signature is required.
 # When implementing non-generic functions, the signature will be inferred from the implementation
-grow_old: (A) -> A
+grow_old A: (A) -> A
     where A: Ageing;
 grow_old = (a: A) -> Ageing.ageing (Ageing.ageing a);
 

--- a/vunk-examples/0042.vunk
+++ b/vunk-examples/0042.vunk
@@ -42,13 +42,13 @@ func_b a = a + 1;
 
 # A simple function
 # with type declaration and generics
-func_c: (C) -> C
+func_c C: (C) -> C
     where C: Std.Op.Add;
 func_c a = a + 1;
 
 # A less simple function
 # with type declaration and generics
-func_d: (C, C) -> C
+func_d C: (C, C) -> C
     where C: Std.Op.Add;
 func_d a b: a + b;
 


### PR DESCRIPTION
With this, we list the generic parameters before the declaration of the function type, which is a lot clearer than just "inferring" the generic parameters from the signature.