### PR TITLE
Simplify mapping to Token::Dollar

### DIFF
--- a/vunk-lexer/src/lib.rs
+++ b/vunk-lexer/src/lib.rs
@@ -155,7 +155,7 @@ pub fn lexer<'src>() -> impl Parser<'src, &'src str, Vec<Spanned<Token<'src>>>, 
 
             _ => Token::Ident(ident),
         })
-        .or(just("$").map(|_| Token::Dollar));
+        .or(just("$").to(Token::Dollar));
 
     let comment = just("#")
         .then(any().and_is(just('\n').not()).repeated())


### PR DESCRIPTION
As suggested in #29 simplify the mapping to `Token::Dollar`.