### PR TITLE
Remove the .to(()) as delimited_by ignores these anyways

### DIFF
--- a/vunk-parser/src/expr.rs
+++ b/vunk-parser/src/expr.rs
@@ -132,8 +132,8 @@ impl Expr<'_> {
             // };
 
             let list_parser = {
-                let left_br = just(Token::Op("[")).to(());
-                let right_br = just(Token::Op("]")).to(());
+                let left_br = just(Token::Op("["));
+                let right_br = just(Token::Op("]"));
 
                 expr.clone().delimited_by(left_br, right_br)
             };


### PR DESCRIPTION
As suggested in #29 remove unnecessary mapping of delimiters.