### PR TITLE
Fix tokenizing comments

### DIFF
--- a/vunk-lexer/src/lib.rs
+++ b/vunk-lexer/src/lib.rs
@@ -158,9 +158,9 @@ pub fn lexer<'src>() -> impl Parser<'src, &'src str, Vec<Spanned<Token<'src>>>, 
         .or(just("$").map(|_| Token::Dollar));
 
     let comment = just("#")
-        .then(any().and_is(just('\n').not()).repeated())
+        .ignore_then(any().and_is(just('\n').not()).repeated().slice())
         .padded()
-        .map(|(comment, ())| Token::Comment(comment));
+        .map(Token::Comment);
 
     num.or(str_)
         .or(ident)


### PR DESCRIPTION
As suggested in #29 fix the tokenizing of comments and simplify the code as well.